### PR TITLE
adding code coverage through the vm code

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,8 @@ var expect = require('chai').expect;
 var through = require('through2');
 var unstyle = require('unstyle');
 
+var vmProcess = {};
+
 var mod = {
   filename: require.resolve('../')
 };
@@ -18,7 +20,8 @@ Object.defineProperty(mod, 'lib', {
   enumerable: true,
   configurable: false,
   get: function () {
-    return require(mod.filename);
+    return getLibInVm(vmProcess);
+//    return require(mod.filename);
   }
 });
 
@@ -79,10 +82,14 @@ function getLibInVm(proc) {
     exports: {}
   };
 
-  vm.runInThisContext(code, {
-    filename: vmModule.filename,
-    columnOffset: start.length
-  })(vmModule.exports, require, vmModule, fakeProcess);
+  // this is wrong, but is the API that istanbul uses
+  vm.runInThisContext(code, mod.filename)(vmModule.exports, require, vmModule, fakeProcess);
+
+  // this is the correct node API, but breaks istanbul coverage
+//  vm.runInThisContext(code, {
+//    filename: libFilename,
+//    columnOffset: start.length
+//  })(vmModule.exports, require, vmModule, fakeProcess);
 
   return vmModule.exports;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,14 @@ var expect = require('chai').expect;
 var through = require('through2');
 var unstyle = require('unstyle');
 
-var CONFUSING_COVERAGE = true;
+// Only run tests entirely thorugh the vm when
+// running the npm coverage script. Otherwise,
+// run the code directly.
+var CONFUSING_COVERAGE = !!(
+  process.env.npm_lifecycle_event &&
+  process.env.npm_lifecycle_event === 'coverage'
+);
+
 var vmProcess = {};
 
 var mod = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,8 +97,6 @@ function getLibInVm(proc) {
       columnOffset: start.length
     };
 
-  // TODO cannot use this if any test ran outside the vm,
-  // because of bugs in istanbul
   vm.runInThisContext(code, vmOpts)(vmModule.exports, require, vmModule, fakeProcess);
 
   return vmModule.exports;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,10 @@ Object.defineProperty(mod, 'lib', {
   enumerable: true,
   configurable: false,
   get: function () {
+    // run all tests through the vm
     return getLibInVm(vmProcess);
+
+    // run non-vm tests outside of the vm
 //    return require(mod.filename);
   }
 });
@@ -83,6 +86,8 @@ function getLibInVm(proc) {
   };
 
   // this is wrong, but is the API that istanbul uses
+  // TODO cannot use this if any test ran outside the vm,
+  // because of bugs in istanbul
   vm.runInThisContext(code, mod.filename)(vmModule.exports, require, vmModule, fakeProcess);
 
   // this is the correct node API, but breaks istanbul coverage


### PR DESCRIPTION
With this update, all of the tests will run through the VM code, rather than directly against the module. This makes code coverage possible.

It's worth noting here that it is not possible to mix the two implementations. If tests are run through the module first, followed by the VM, coverage will fail to report due to the modified code in the VM.